### PR TITLE
Added jumper determined device addressing

### DIFF
--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.github/workflows/main.yaml
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.github/workflows/main.yaml
@@ -1,0 +1,37 @@
+# Particle Compile Action Workflow
+# This workflow uses the Particle compile-action to compile Particle application firmware.
+# Make sure to set the particle-platform-name for your project.
+# For complete documentation, please refer to https://github.com/particle-iot/compile-action
+
+name: Particle Compile
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # Particle Compile Action
+      - name: Compile Firmware
+        id: compile
+        uses: particle-iot/compile-action@v1
+        with:
+          # Set the particle-platform-name to the platform you're targeting.
+          # Allowed values: core, photon, p1, electron, argon, boron, xenon, esomx, bsom, b5som, tracker, trackerm, p2, msom
+          particle-platform-name: 'p2'
+
+      # Optional: Upload compiled firmware as an artifact on GitHub.
+      - name: Upload Firmware as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmware-artifact
+          path: |
+            ${{ steps.compile.outputs.firmware-path }}
+            ${{ steps.compile.outputs.target-path }}

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.gitignore
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.gitignore
@@ -1,0 +1,55 @@
+# Key files
+*.der
+*.pem
+
+# Ignore build results and bundles
+*.bin
+*.zip
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+target/*
+
+# Platform-specific settings
+.DS_Store
+*.crc_block
+*.no_crc
+
+# VisualStudioCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Ignore all local history of files
+**/.history
+
+# Windows
+Thumbs.db
+*.stackdump
+[Dd]esktop.ini
+
+# C Prerequisites
+*.d
+
+# C Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# C Linker output
+*.map
+
+# C Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.vscode/launch.json
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.vscode/launch.json
@@ -1,0 +1,53 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "cortex-debug",
+            "request": "attach",
+            "servertype": "openocd",
+            "name": "Particle Debugger",
+            "cwd": "${workspaceRoot}",
+            "rtos": "FreeRTOS",
+            "armToolchainPath": "${command:particle.getDebuggerCompilerDir}",
+            "executable": "${command:particle.getDebuggerExecutable}",
+            "serverpath": "${command:particle.getDebuggerOpenocdPath}",
+            "searchDir": [
+                "${command:particle.getDebuggerSearchDir}"
+            ],
+            "configFiles": [
+                "${command:particle.getDebuggerConfigFiles}"
+            ],
+            "postAttachCommands": [
+                "${command:particle.getDebuggerPostAttachCommands}"
+            ],
+            "particle": {
+                "version": "1.1.0",
+                "debugger": "particle-debugger"
+            }
+        },
+        {
+            "type": "cortex-debug",
+            "request": "attach",
+            "servertype": "openocd",
+            "name": "Generic DAPLink Compatible Debugger",
+            "cwd": "${workspaceRoot}",
+            "rtos": "FreeRTOS",
+            "armToolchainPath": "${command:particle.getDebuggerCompilerDir}",
+            "executable": "${command:particle.getDebuggerExecutable}",
+            "serverpath": "${command:particle.getDebuggerOpenocdPath}",
+            "searchDir": [
+                "${command:particle.getDebuggerSearchDir}"
+            ],
+            "configFiles": [
+                "${command:particle.getDebuggerConfigFiles}"
+            ],
+            "postAttachCommands": [
+                "${command:particle.getDebuggerPostAttachCommands}"
+            ],
+            "particle": {
+                "version": "1.1.0",
+                "debugger": "generic-cmsis-dap"
+            }
+        }
+    ]
+}

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.vscode/settings.json
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "extensions.ignoreRecommendations": true,
+    "C_Cpp.default.configurationProvider": "particle.particle-vscode-core",
+    "files.associations": {
+        "*.ino": "cpp"
+    },
+    "particle.targetDevice": "Dryer",
+    "particle.targetPlatform": "photon",
+    "particle.firmwareVersion": "3.3.0"
+}

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/README.md
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/README.md
@@ -1,0 +1,100 @@
+# LoRa_Sensor_Tester
+
+This firmware project was created using [Particle Developer Tools](https://www.particle.io/developer-tools/) and is compatible with all [Particle Devices](https://www.particle.io/devices/).
+
+Feel free to replace this README.md file with your own content, or keep it for reference.
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Prerequisites To Use This Template](#prerequisites-to-use-this-repository)
+- [Getting Started](#getting-started)
+- [Particle Firmware At A Glance](#particle-firmware-at-a-glance)
+  - [Logging](#logging)
+  - [Setup and Loop](#setup-and-loop)
+  - [Delays and Timing](#delays-and-timing)
+  - [Testing and Debugging](#testing-and-debugging)
+  - [GitHub Actions (CI/CD)](#github-actions-cicd)
+  - [OTA](#ota)
+- [Support and Feedback](#support-and-feedback)
+- [Version](#version)
+
+## Introduction
+
+For an in-depth understanding of this project template, please refer to our [documentation](https://docs.particle.io/firmware/best-practices/firmware-template/).
+
+## Prerequisites To Use This Repository
+
+To use this software/firmware on a device, you'll need:
+
+- A [Particle Device](https://www.particle.io/devices/).
+- Windows/Mac/Linux for building the software and flashing it to a device.
+- [Particle Development Tools](https://docs.particle.io/getting-started/developer-tools/developer-tools/) installed and set up on your computer.
+- Optionally, a nice cup of tea (and perhaps a biscuit).
+
+## Getting Started
+
+1. While not essential, we recommend running the [device setup process](https://setup.particle.io/) on your Particle device first. This ensures your device's firmware is up-to-date and you have a solid baseline to start from.
+
+2. If you haven't already, open this project in Visual Studio Code (File -> Open Folder). Then [compile and flash](https://docs.particle.io/getting-started/developer-tools/workbench/#cloud-build-and-flash) your device. Ensure your device's USB port is connected to your computer.
+
+3. Verify the device's operation by monitoring its logging output:
+    - In Visual Studio Code with the Particle Plugin, open the [command palette](https://docs.particle.io/getting-started/developer-tools/workbench/#particle-commands) and choose "Particle: Serial Monitor".
+    - Or, using the Particle CLI, execute:
+    ```
+    particle serial monitor --follow
+    ```
+
+4. Uncomment the code at the bottom of the cpp file in your src directory to publish to the Particle Cloud! Login to console.particle.io to view your devices events in real time.
+
+5. Customize this project! For firmware details, see [Particle firmware](https://docs.particle.io/reference/device-os/api/introduction/getting-started/). For information on the project's directory structure, visit [this link](https://docs.particle.io/firmware/best-practices/firmware-template/#project-overview).
+
+## Particle Firmware At A Glance
+
+### Logging
+
+The firmware includes a [logging library](https://docs.particle.io/reference/device-os/api/logging/logger-class/). You can display messages at different levels and filter them:
+
+```
+Log.trace("This is trace message");
+Log.info("This is info message");
+Log.warn("This is warn message");
+Log.error("This is error message");
+```
+
+### Setup and Loop
+
+Particle projects originate from the Wiring/Processing framework, which is based on C++. Typically, one-time setup functions are placed in `setup()`, and the main application runs from the `loop()` function.
+
+For advanced scenarios, explore our [threading support](https://docs.particle.io/firmware/software-design/threading-explainer/).
+
+### Delays and Timing
+
+By default, the setup() and loop() functions are blocking whilst they run, meaning that if you put in a delay, your entire application will wait for that delay to finish before anything else can run. 
+
+For techniques that allow you to run multiple tasks in parallel without creating threads, checkout the code example [here](https://docs.particle.io/firmware/best-practices/firmware-template/).
+
+(Note: Although using `delay()` isn't recommended for best practices, it's acceptable for testing.)
+
+### Testing and Debugging
+
+For firmware testing and debugging guidance, check [this documentation](https://docs.particle.io/troubleshooting/guides/build-tools-troubleshooting/debugging-firmware-builds/).
+
+### GitHub Actions (CI/CD)
+
+This project provides a YAML file for GitHub, automating firmware compilation whenever changes are pushed. More details on [Particle GitHub Actions](https://docs.particle.io/firmware/best-practices/github-actions/) are available.
+
+### OTA
+
+To learn how to utilize Particle's OTA service for device updates, consult [this documentation](https://docs.particle.io/getting-started/cloud/ota-updates/).
+
+Test OTA with the 'Particle: Cloud Flash' command in Visual Studio Code or the CLI command 'particle flash'!
+
+This firmware supports binary assets in OTA packages, allowing the inclusion of audio, images, configurations, and external microcontroller firmware. More details are [here](https://docs.particle.io/reference/device-os/api/asset-ota/asset-ota/).
+
+## Support and Feedback
+
+For support or feedback on this template or any Particle products, please join our [community](https://community.particle.io)!
+
+## Version
+
+Template version 1.0.2

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/project.properties
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/project.properties
@@ -1,0 +1,2 @@
+name=LoRa_Sensor_Tester
+#assetOtaDir=assets

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.cpp
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.cpp
@@ -1,0 +1,55 @@
+/* 
+ * Project LoRa Sensor Tester
+ * Author: Bob Glicksman
+ * Date: 12/18/24
+ * 
+ * This project is a Photon 1 based tester for a LoRa sensor.  It uses the TPP Wireless I/O Board
+ *  with a relay installed.  The Tester simply loops a preset number of times, closing the relay and
+ *  opening it at 6 second intervals.  The results of the sensor tests can be seen in the Google
+ *  spreadsheet logs.
+ * 
+ * Version 1.00 - Initial release.
+ * 
+ *  (c) 2024, by Bob Glicksman, Jim Schrempp, Team Practical Projects
+ */
+
+// Include Particle Device OS APIs
+#include "Particle.h"
+
+// Let Device OS manage the connection to the Particle Cloud
+SYSTEM_MODE(AUTOMATIC);
+
+// Run the application and system concurrently in separate threads
+SYSTEM_THREAD(ENABLED);
+
+#define NUMBER_OF_SENSOR_TRIPS 10
+#define SENSOR_ON_TIME 1000
+#define SENSOR_OFF_TIME 5000
+
+#define RELAY_PIN D0
+#define LED_PIN D13
+
+
+void setup() {
+  pinMode(RELAY_PIN, OUTPUT);
+  pinMode(LED_PIN, OUTPUT);
+
+  // loop through NUMBER_OF_SENSOR_TRIPS times, closing and opening the relay
+  for(int i = 0; i < NUMBER_OF_SENSOR_TRIPS; i++) {
+    digitalWrite(RELAY_PIN, HIGH);
+    digitalWrite(LED_PIN, HIGH);
+    delay(SENSOR_ON_TIME);
+    digitalWrite(RELAY_PIN, LOW);
+    digitalWrite(LED_PIN, LOW);
+    delay(SENSOR_OFF_TIME);
+  }
+
+
+}
+
+
+void loop() {
+
+  // Nothing here!
+
+}

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.ino
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.ino
@@ -22,7 +22,7 @@ SYSTEM_MODE(AUTOMATIC);
 // Run the application and system concurrently in separate threads
 SYSTEM_THREAD(ENABLED);
 
-#define NUMBER_OF_SENSOR_TRIPS 5
+#define NUMBER_OF_SENSOR_TRIPS 1000
 #define SENSOR_ON_TIME 2000
 #define SENSOR_OFF_TIME 8000
 

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.ino
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.ino
@@ -1,0 +1,62 @@
+/* 
+ * Project LoRa Sensor Tester
+ * Author: Bob Glicksman
+ * Date: 12/18/24
+ * 
+ * This project is a Photon 1 based tester for a LoRa sensor.  It uses the TPP Wireless I/O Board
+ *  with a relay installed and an LED connected to the LED terminal block.  The Tester simply loops 
+ *  a preset number of times, closing the relay and  opening it at 10 second intervals.  
+ *  The results of the sensor tests can be seen in the Google spreadsheet logs.
+ * 
+ * Version 1.00 - Initial release.
+ * 
+ *  (c) 2024, by Bob Glicksman, Jim Schrempp, Team Practical Projects
+ */
+
+// Include Particle Device OS APIs
+#include "Particle.h"
+
+// Let Device OS manage the connection to the Particle Cloud
+SYSTEM_MODE(AUTOMATIC);
+
+// Run the application and system concurrently in separate threads
+SYSTEM_THREAD(ENABLED);
+
+#define NUMBER_OF_SENSOR_TRIPS 5
+#define SENSOR_ON_TIME 2000
+#define SENSOR_OFF_TIME 8000
+
+#define RELAY_PIN D0
+#define LED_PIN D5
+#define INTERNAL_LED_PIN D7
+
+
+void setup() {
+  pinMode(RELAY_PIN, OUTPUT);
+  pinMode(LED_PIN, OUTPUT);
+  pinMode(INTERNAL_LED_PIN, OUTPUT);
+
+  // signal that the Photon is reset and getting ready to test
+  digitalWrite(INTERNAL_LED_PIN, HIGH);
+  delay(5000); 
+  digitalWrite(INTERNAL_LED_PIN, LOW);
+
+  // loop through NUMBER_OF_SENSOR_TRIPS times, closing and opening the relay
+  for(int i = 0; i < NUMBER_OF_SENSOR_TRIPS; i++) {
+    digitalWrite(RELAY_PIN, HIGH);
+    digitalWrite(LED_PIN, HIGH);
+    delay(SENSOR_ON_TIME);
+    digitalWrite(RELAY_PIN, LOW);
+    digitalWrite(LED_PIN, LOW);
+    delay(SENSOR_OFF_TIME);
+  }
+
+
+}
+
+
+void loop() {
+
+  // Nothing here!
+
+}

--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/Low_power_ATmega328_LoRa_integration.old1
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/Low_power_ATmega328_LoRa_integration.old1
@@ -71,39 +71,21 @@
  *      the sensor message to shorten it and to include a "one up" number so that we can check for missed
  *      messages at the hub (or upstream of the hub).
  *      
- *    Version 1.40, by Bob Glicksman, 12/17/24
- *      this version adds in jumper-determined device addressing.  3 pins are used to create a 0 - 7 offset to a base
- *      device address (base device address is a defined constant).  Arduino pin 10 (chip pin 16) adds 1 to the base
- *      device address when not grounded.  Arduino pin 11 (chip pin 17) adds 2 to the base device address when not grounded,
- *      and Arduino pin 12 (chip pin 18) adds 4 to the base device address when not grounded.  The device address is written
- *      to the LoRa module during setup(), so the device must be reset in order to change addresses.
- *      
- *      After reading these I/O pins, the pinMode is changed from INPUT_PULLUP to INPUT to conserve power.
- *      
- *      This version of the code also uses the F() macro for all string literals which avoids them being copied 
- *      from program memory to RAM an extra time.
- *      
  *    (c) 2024, Bob Glicksman, Jim Schrempp, Team Practical Projects.  All rights reserved.
  */
 
 #include <avr/sleep.h>  // the official avr sleep library
 
-#define VERSION 1.40
+#define VERSION 1.30
 
 #define DEBUG
 
 #define HUB_ADDRESS 57248 // hub address for mailbox/door/gate sensor
 
-#define BASE_DEVICE_ADDRESS 12000 // the base address for this class of sensor.  Jumpers will modify the actual device address. 
-
 // CONSTANTS
 const int BUTTON_PIN = 2; // the pushbutton is on digital pin 2 which is chip pin 4
 const int GRN_LED_PIN = 9;  // the Green LED is on digital pin 9 which is chip pin 15
 const int RED_LED_PIN = 8;  // the Red LED is on digital pin 8 which is chip pin 14
-
-const int ADR1_PIN = 10;  // the device address = BASE_DEVICE_ADDRESS + (ADR4 + ADR2 + ADR1)
-const int ADR2_PIN = 11;  // the device address = BASE_DEVICE_ADDRESS + (ADR4 + ADR2 + ADR1)
-const int ADR4_PIN = 12;  // the device address = BASE_DEVICE_ADDRESS + (ADR4 + ADR2 + ADR1)
 
 // Globals
 String messageBuffer;
@@ -115,54 +97,16 @@ void setup() {
   pinMode(GRN_LED_PIN, OUTPUT); // the green LED pin is Arduino DIO 9, chip pin 15.
   pinMode(RED_LED_PIN, OUTPUT); // the red LED pin is Arduino DIO 8, chip pin 14.
 
-  // set address line pin mode for pullup temporarily
-  uint16_t deviceAddress = BASE_DEVICE_ADDRESS;
-  
-  pinMode(ADR4_PIN, INPUT_PULLUP);
-  pinMode(ADR2_PIN, INPUT_PULLUP);
-  pinMode(ADR1_PIN, INPUT_PULLUP);
-
-  // compute the device's address based upon jumpers
-  if(digitalRead(ADR4_PIN) == HIGH) {
-    deviceAddress += 4;
-  }
-  if(digitalRead(ADR2_PIN) == HIGH) {
-    deviceAddress += 2;
-  }
-  if(digitalRead(ADR1_PIN) == HIGH) {
-    deviceAddress += 1;
-  }
-
-  // change the address pins to eliminate pullups for lowest power consumption when sleeping
-  pinMode(ADR4_PIN, INPUT);
-  pinMode(ADR2_PIN, INPUT);
-  pinMode(ADR1_PIN, INPUT);
-
-  // set up the serial port to talk to the LoRa module
-  
   Serial.begin(38400);  // the LoRa device baud rate
   Serial.setTimeout(10);  // a full string is received after 10 ms of no new data from the LoRa device
 
   // reserve space in a message buffer string for message assembly
   messageBuffer.reserve(32);  // this is larger than the sensor trip message will ever be
 
-  // initial comms with the LoRa module
-  Serial.println(F("AT"));
-  waitForOK();
-
-  // set the device address into the LoRa module
-  
-  messageBuffer = F("AT+ADDRESS=");
-  messageBuffer += deviceAddress;
-  Serial.println(messageBuffer);
-  if(waitForOK() == -1) { // only flash the LED if did not get +OK
-    #ifdef DEBUG
-    blinkLed(RED_LED_PIN, 2);
-    #endif
-  }
-
   // put the LoRa module to sleep
-  Serial.println(F("AT+MODE=1")); 
+  Serial.println("AT");
+  waitForOK();
+  Serial.println("AT+MODE=1"); 
   if(waitForOK() == -1) { // only flash the LED if did not get +OK
     #ifdef DEBUG
     blinkLed(RED_LED_PIN, 3);
@@ -210,10 +154,10 @@ void loop() {
   #endif
   
   // wake up the LoRa module
-  Serial.println(F("AT+MODE=0"));  // mode 0 is the normal tranceiver mode of the LoRa module
+  Serial.println("AT+MODE=0");  // mode 0 is the normal tranceiver mode of the LoRa module
   waitForOK();  // something other than +OK comes back after the LoRa is powered down
   //  try again to make sure that we are powered up - got +OK
-  Serial.println(F("AT+MODE=0"));    
+  Serial.println("AT+MODE=0");    
   if(waitForOK() == -1) { // only flash the LED if did not get +OK
     #ifdef DEBUG
     blinkLed(RED_LED_PIN, 1);
@@ -221,12 +165,13 @@ void loop() {
   }
 
   // assemble the sensor trip message in the message buffer
-  messageBuffer = F("AT+SEND="); // the message preamble
+  messageBuffer = "AT+SEND="; // the message preamble
   messageBuffer += HUB_ADDRESS;
   messageBuffer += ",6,G m: ";
   messageBuffer += (msgNum++)%10;
    
   // send out the contact closed message
+  //Serial.println("AT+SEND=57248,28,HELLO m: 2 rssi: -21 snr: 11");  // just a dummy message for testing
   Serial.println(messageBuffer);
   if(waitForOK() == -1) { // only flash the LED if did not get +OK
     #ifdef DEBUG
@@ -234,8 +179,10 @@ void loop() {
     #endif
   }
 
+  // delay(1); // need to wait for xmit to complete before sleeping the LoRa module
+
   // put the LoRa module to sleep
-  Serial.println(F("AT+MODE=1"));
+  Serial.println("AT+MODE=1");
   if(waitForOK() == -1) { // only flash the LED if did not get +OK
     #ifdef DEBUG
     blinkLed(RED_LED_PIN, 3);
@@ -287,7 +234,7 @@ int waitForOK() {
   String receivedData = Serial.readString();
 
   // test for "+OK"
-  if(receivedData.indexOf(F("+OK")) >= 0) { // got an +OK
+  if(receivedData.indexOf("+OK") >= 0) { // got an +OK
     return 0;
   } else {
     return -1;


### PR DESCRIPTION
The LoRa module device address is now programmed into the module during setup().  The device address is equal to a #define base device address plus a jumper determined offset.  #define AD4, AD2 and AD1 pins determine the address offset where AD4 is MSB and AD1 is LSB.  Nominal pin assignments are Arduino pin 12  (chip pin 18) is ADR4, pin 11 (chip pin 17) is ADR2 and pin 10 (chip pin 16) is ADR1.  Leaving the pin open is a 1 in that bit position, grounding the pin is a 0 in that bit position.  This allows 8 distinct sensors of any given type (any given base address).

Additionally, all string literals now use the F() macro to avoid them taking up added RAM space.