### PR TITLE
Arduino production code version 2.6.1 - added a message during setup to log resets; changed tester code for 60 sec intervals

### DIFF
--- a/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.ino
+++ b/Integration_testing/Low_power_ATmega328_LoRa_integration/LoRa_Sensor_Tester/src/LoRa_Sensor_Tester.ino
@@ -22,9 +22,9 @@ SYSTEM_MODE(AUTOMATIC);
 // Run the application and system concurrently in separate threads
 SYSTEM_THREAD(ENABLED);
 
-#define NUMBER_OF_SENSOR_TRIPS 1000
+#define NUMBER_OF_SENSOR_TRIPS 300
 #define SENSOR_ON_TIME 2000
-#define SENSOR_OFF_TIME 8000
+#define SENSOR_OFF_TIME 58000
 
 #define RELAY_PIN D0
 #define LED_PIN D5

--- a/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
+++ b/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
@@ -48,6 +48,7 @@
     v 2.4 integrates ATmega power down code
     v 2.5 now calls setAddress for the LoRa module in setup
     v 2.6 processes address jumper pins to alter the sensor device address
+    v 2.6.1 added transmission of a reset message to indicate setup run
  */
 
 #include "tpp_LoRaGlobals.h"
@@ -68,7 +69,7 @@
     #include <avr/sleep.h>  // the official avr sleep library
 #endif
 
-#define VERSION 2.6
+#define VERSION 2.6.1
 #define STATION_NUM 0 // housekeeping; not used ini the code
 
 #define THIS_LORA_DEFAULT_SENSOR_ADDRESS 5 // the address of the sensor
@@ -211,6 +212,13 @@ void setup() {
         mgFatalError = true;
         blinkLEDsOnERROR(13,err);
     }
+
+    // XXX send out a message for testing resets.  Comment this out after stree testing.
+
+    mgpayload = F("The ATMega328 has reset");
+    LoRa.transmitMessage(TPP_LORA_HUB_ADDRESS, mgpayload);
+
+    // XXX end of reset test message
     
     if (!mgFatalError) {
         int errRtn = LoRa.sleep(); // put the LoRa module to sleep


### PR DESCRIPTION
Added sending a reset test message at the end of setup() so that any resets during stress testing will be logged (lines 216 - 221).  This is intended as temporary code for stress testing the production sensor code on ATMega328 only.  There is no harm in leaving this for the final version and porting it over to the Photon code as well.  However, error returns from the message transmission are not processed for errors.

The tester (Photon) code has also been changes to trip the sensor (relay) every 60 seconds vs every 10 seconds.  At this larger interval, the logged data is mostly in the order that it was sent, and the test is more realistic of the intended application.